### PR TITLE
Catch subsystem is down exception

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+dotnet build -c Release /p:AssemblyVersion=2.0.0.0 src/Nakama/Nakama.csproj
+dotnet pack -p:AssemblyVersion=2.0.0.0 -p:PackageVersion=2.0.0 -c Release src/Nakama/Nakama.csproj

--- a/src/Nakama/WebSocketAdapter.cs
+++ b/src/Nakama/WebSocketAdapter.cs
@@ -217,8 +217,16 @@ namespace Nakama
                     return new ArraySegment<byte>();
                 }
 
-                result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, count, MaxMessageSize - count),
-                    CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer, count, MaxMessageSize - count),
+                        CancellationToken.None).ConfigureAwait(false);
+                } catch(SocketException)
+                {
+                    ReceivedError?.Invoke(new WebSocketException(WebSocketError.Faulted));
+                    return new ArraySegment<byte>();
+                }
+                
                 count += result.Count;
             }
 


### PR DESCRIPTION
## Overview
[Notion card](https://www.notion.so/gamelynx/Fix-Socket-subsystem-is-down-734f23b6065a43f6b6b216c26d16b45f)

quantum-brawl PR: https://github.com/gamelynx/quantum-brawl/pull/2398

## Todo

- [x]  (45m) Pull the nakama source code repo, get it to build
    - [x]  Run another PR bot on this new repository.
- [x]  (15m) Create an internal gamelynx github repo for this
- [x]  (15m) add a try/catch around 220 here: [https://github.com/heroiclabs/nakama-dotnet/blob/master/src/Nakama/WebSocketAdapter.cs](https://github.com/heroiclabs/nakama-dotnet/blob/master/src/Nakama/WebSocketAdapter.cs)
    - [x]  You should probably call the error handler callback for this? Seems like the right thing to do, see example code in that file
- [x]  (30m) Rebuild + import into unity + test to make sure the error is not happening anymore
    - [x]  Also create PRs for fix, one PR should be a quantum-brawl PR importing the new DLL and the second PR should be a PR on the nakama-dotnet repository.
- [ ]  This issue is related to the operation canceled exception, if you notice that after completing this card that we no longer get the operation canceled exception, mark this card complete
    - [ ]  [https://www.notion.so/gamelynx/Fix-Operation-canceled-exception-0612a97df74b4373af81b928528e961a](https://www.notion.so/gamelynx/Fix-Operation-canceled-exception-0612a97df74b4373af81b928528e961a)
- [ ]  30m Review
- [x]  30m Unknown

## Testing

Easy testing:
- [x] Open app, let it fully connect
- [x] Disable wifi, you should get no errors

Longer testing:
- [x]  Login fully to nakama
- [x]  Lock your phone for like 15m
- [x]  Come back and you shouldn't get a subsystem error anymore
